### PR TITLE
Support NotificationChannel for android platform

### DIFF
--- a/notice.go
+++ b/notice.go
@@ -10,6 +10,7 @@ type Notice struct {
 type AndroidNotice struct {
 	Alert     string                 `json:"alert"`
 	Title     string                 `json:"title,omitempty"`
+	Channel   string                 `json:"channel_id,omitempty"`
 	BuilderId int                    `json:"builder_id,omitempty"`
 	Extras    map[string]interface{} `json:"extras,omitempty"`
 }


### PR DESCRIPTION
Starting in Android 8.0 (API level 26), all notifications must be assigned to a channel